### PR TITLE
Update css theme for mobile users

### DIFF
--- a/sigma9.css
+++ b/sigma9.css
@@ -1309,7 +1309,7 @@ z-index: 1;
 
 .open-menu a {
 	position: fixed;
-	bottom: 0.5em;
+	top: 0.5em;
 	left: 0.5em;
 	z-index: 15;
 	font-family: 'Nanum Gothic', san-serif;


### PR DESCRIPTION
Users would have the side menus drawn over on mobile when not signed in.  

Changing the menu to top, rather than bottom offset will avoid the issue.